### PR TITLE
Changed folder named aux to auxiliary

### DIFF
--- a/DungeonsRedux/src/net/robotmedia/billing/example/Dungeons.java
+++ b/DungeonsRedux/src/net/robotmedia/billing/example/Dungeons.java
@@ -20,8 +20,8 @@ import java.util.List;
 
 import net.robotmedia.billing.BillingController;
 import net.robotmedia.billing.example.R;
-import net.robotmedia.billing.example.aux.CatalogAdapter;
-import net.robotmedia.billing.example.aux.CatalogEntry;
+import net.robotmedia.billing.example.auxiliary.CatalogAdapter;
+import net.robotmedia.billing.example.auxiliary.CatalogEntry;
 import net.robotmedia.billing.helper.AbstractBillingObserver;
 import net.robotmedia.billing.model.Transaction;
 import net.robotmedia.billing.model.Transaction.PurchaseState;

--- a/DungeonsRedux/src/net/robotmedia/billing/example/auxiliary/CatalogAdapter.java
+++ b/DungeonsRedux/src/net/robotmedia/billing/example/auxiliary/CatalogAdapter.java
@@ -1,4 +1,4 @@
-package net.robotmedia.billing.example.aux;
+package net.robotmedia.billing.example.auxiliary;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/DungeonsRedux/src/net/robotmedia/billing/example/auxiliary/CatalogEntry.java
+++ b/DungeonsRedux/src/net/robotmedia/billing/example/auxiliary/CatalogEntry.java
@@ -1,4 +1,4 @@
-package net.robotmedia.billing.example.aux;
+package net.robotmedia.billing.example.auxiliary;
 
 import net.robotmedia.billing.example.R;
 


### PR DESCRIPTION
aux is a reserved file name in Windows 7 and as a result it makes cloning the repository or extracting an archive of the project and arduous task.  We've re-factored folder aux in DungeonsRedux to auxiliary.
