### PR TITLE
Handling Transaction Restore Failed error

### DIFF
--- a/AndroidBillingLibrary/src/net/robotmedia/billing/BillingController.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/BillingController.java
@@ -432,6 +432,12 @@ public class BillingController {
 			o.onTransactionsRestored();
 		}
 	}
+	
+	protected static void onTransactionsRestoreFailed() {
+		for (IBillingObserver o : observers) {
+			o.onTransactionsRestoreFailed();
+		}
+	}
 
 	/**
 	 * Parse all purchases from the JSON data received from the Market Billing

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/BillingController.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/BillingController.java
@@ -635,4 +635,10 @@ public class BillingController {
 		}
 	}
 
+	protected static void onServiceError() {
+		for (IBillingObserver o : observers) {
+			o.onServiceError();
+		}
+	}
+
 }

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/BillingRequest.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/BillingRequest.java
@@ -171,6 +171,9 @@ public abstract class BillingRequest {
     		if (response == ResponseCode.RESULT_OK) {
     			BillingController.onTransactionsRestored();
     		}
+    		else if (response == ResponseCode.RESULT_SERVICE_UNAVAILABLE) {
+    			BillingController.onTransactionsRestoreFailed();
+    		}
     	}
     	
     }

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/BillingService.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/BillingService.java
@@ -231,7 +231,10 @@ public class BillingService extends Service implements ServiceConnection {
 			BillingController.onRequestSent(requestId, request);
 		} catch (RemoteException e) {
 			Log.e(this.getClass().getSimpleName(), "Remote billing service crashed", e);
-			// TODO: Retry?
+			
+			// Use this to make the app to bind market again
+			mService = null;
+			BillingController.onServiceError();
 		}
 	}
 

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/BillingService.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/BillingService.java
@@ -230,7 +230,7 @@ public class BillingService extends Service implements ServiceConnection {
 			final long requestId = request.run(mService);
 			BillingController.onRequestSent(requestId, request);
 		} catch (RemoteException e) {
-			Log.w(this.getClass().getSimpleName(), "Remote billing service crashed");
+			Log.e(this.getClass().getSimpleName(), "Remote billing service crashed", e);
 			// TODO: Retry?
 		}
 	}

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/IBillingObserver.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/IBillingObserver.java
@@ -74,4 +74,9 @@ public interface IBillingObserver {
 	 * Called when a restore transaction request request failed.
 	 */
 	public void onTransactionsRestoreFailed();
+
+	/**
+	 * Called when the market service crash
+	 */
+	public void onServiceError();
 }

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/IBillingObserver.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/IBillingObserver.java
@@ -70,4 +70,8 @@ public interface IBillingObserver {
 	 */
 	public void onTransactionsRestored();
 
+	/**
+	 * Called when a restore transaction request request failed.
+	 */
+	public void onTransactionsRestoreFailed();
 }

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/helper/AbstractBillingActivity.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/helper/AbstractBillingActivity.java
@@ -80,7 +80,7 @@ public abstract class AbstractBillingActivity extends Activity implements Billin
 		BillingController.setConfiguration(null);
 	}
 
-	public abstract void onPurchaseStateChanged(String itemId, PurchaseState state);;
+	public abstract void onPurchaseStateChanged(String itemId, PurchaseState state);
 
 	public abstract void onRequestPurchaseResponse(String itemId, ResponseCode response);
 

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/helper/AbstractBillingObserver.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/helper/AbstractBillingObserver.java
@@ -66,4 +66,8 @@ public abstract class AbstractBillingObserver implements IBillingObserver {
 		editor.commit();
 	}
 
+	@Override
+	public void onTransactionsRestoreFailed() {
+		
+	}
 }

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/helper/AbstractBillingObserver.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/helper/AbstractBillingObserver.java
@@ -70,4 +70,9 @@ public abstract class AbstractBillingObserver implements IBillingObserver {
 	public void onTransactionsRestoreFailed() {
 		
 	}
+	
+	@Override
+	public void onServiceError() {
+		
+	}
 }

--- a/DungeonsRedux/res/values/strings.xml
+++ b/DungeonsRedux/res/values/strings.xml
@@ -25,6 +25,7 @@
      service is not available at this time.  You can continue to use this app but you
      won\'t be able to make purchases.</string>
     <string name="restoring_transactions">Restoring transactions</string>
+    <string name="failed_to_restore_transactions">Fail to restore transaction</string>
     <string name="buy">Buy</string>
     <string name="select_item">Select an item</string>
     <string name="items_for_sale">Items for sale</string>

--- a/DungeonsRedux/src/net/robotmedia/billing/example/Dungeons.java
+++ b/DungeonsRedux/src/net/robotmedia/billing/example/Dungeons.java
@@ -82,6 +82,12 @@ public class Dungeons extends Activity {
 			public void onRequestPurchaseResponse(String itemId, ResponseCode response) {
 				Dungeons.this.onRequestPurchaseResponse(itemId, response);
 			}
+			
+			@Override
+			public void onTransactionsRestoreFailed() {
+				super.onTransactionsRestoreFailed();
+				Toast.makeText(Dungeons.this, R.string.failed_to_restore_transactions, Toast.LENGTH_SHORT).show();
+			}
 		};
 		
 		setContentView(R.layout.main);
@@ -125,7 +131,7 @@ public class Dungeons extends Activity {
 	private void restoreTransactions() {
 		if (!mBillingObserver.isTransactionsRestored()) {
 			BillingController.restoreTransactions(this);
-			Toast.makeText(this, R.string.restoring_transactions, Toast.LENGTH_LONG).show();
+			Toast.makeText(this, R.string.restoring_transactions, Toast.LENGTH_SHORT).show();
 		}
 	}
 


### PR DESCRIPTION
Hi all,

I just added some code to allow handling error when RESULT_SERVICE_UNAVAILABLE is returned from request. You can try this by do a fresh install of the app (uninstall and reinstall again) then turn off all connections and launch the app.

Thanks,
