### PR TITLE
Allow server-side verification of transactions.

### DIFF
--- a/AndroidBillingLibrary/src/net/robotmedia/billing/BillingController.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/BillingController.java
@@ -362,7 +362,7 @@ public class BillingController {
 				Log.w(LOG_TAG, "Invalid nonce");
 				return;
 			}
-			purchases = parsePurchases(jObject);
+			purchases = parsePurchases(jObject, signedData, signature);
 		} catch (JSONException e) {
 			Log.e(LOG_TAG, "JSON exception: ", e);
 			return;
@@ -443,7 +443,7 @@ public class BillingController {
 	 * @throws JSONException
 	 *             if the data couldn't be properly parsed.
 	 */
-	private static List<Transaction> parsePurchases(JSONObject data) throws JSONException {
+	private static List<Transaction> parsePurchases(JSONObject data, String signedData, String signature) throws JSONException {
 		ArrayList<Transaction> purchases = new ArrayList<Transaction>();
 		JSONArray orders = data.optJSONArray(JSON_ORDERS);
 		int numTransactions = 0;
@@ -452,7 +452,7 @@ public class BillingController {
 		}
 		for (int i = 0; i < numTransactions; i++) {
 			JSONObject jElement = orders.getJSONObject(i);
-			Transaction p = Transaction.parse(jElement);
+			Transaction p = Transaction.parse(jElement, signedData, signature);
 			purchases.add(p);
 		}
 		return purchases;

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/model/BillingDB.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/model/BillingDB.java
@@ -32,10 +32,13 @@ public class BillingDB {
     public static final String COLUMN_PRODUCT_ID = "productId";
     public static final String COLUMN_PURCHASE_TIME = "purchaseTime";
     public static final String COLUMN_DEVELOPER_PAYLOAD = "developerPayload";
+    public static final String COLUMN_SIGNED_DATA = "signedData";
+    public static final String COLUMN_SIGNATURE = "signature";
 
     private static final String[] TABLE_TRANSACTIONS_COLUMNS = {
     	COLUMN__ID, COLUMN_PRODUCT_ID, COLUMN_STATE,
-    	COLUMN_PURCHASE_TIME, COLUMN_DEVELOPER_PAYLOAD
+    	COLUMN_PURCHASE_TIME, COLUMN_DEVELOPER_PAYLOAD,
+    	COLUMN_SIGNED_DATA, COLUMN_SIGNATURE,
     };
 
     SQLiteDatabase mDb;
@@ -57,6 +60,8 @@ public class BillingDB {
         values.put(COLUMN_STATE, transaction.purchaseState.ordinal());
         values.put(COLUMN_PURCHASE_TIME, transaction.purchaseTime);
         values.put(COLUMN_DEVELOPER_PAYLOAD, transaction.developerPayload);
+        values.put(COLUMN_SIGNED_DATA, transaction.signedData);
+        values.put(COLUMN_SIGNATURE, transaction.signature);
         mDb.replace(TABLE_TRANSACTIONS, null /* nullColumnHack */, values);
     }
     
@@ -82,6 +87,8 @@ public class BillingDB {
     	purchase.purchaseState = PurchaseState.valueOf(cursor.getInt(2));
     	purchase.purchaseTime = cursor.getLong(3);
     	purchase.developerPayload = cursor.getString(4);
+    	purchase.signedData = cursor.getString(5);
+    	purchase.signature = cursor.getString(6);
     	return purchase;
     }
 
@@ -101,7 +108,9 @@ public class BillingDB {
             		COLUMN_PRODUCT_ID + " INTEGER, " +
             		COLUMN_STATE + " TEXT, " +
             		COLUMN_PURCHASE_TIME + " TEXT, " +
-            		COLUMN_DEVELOPER_PAYLOAD + " INTEGER)");
+            		COLUMN_DEVELOPER_PAYLOAD + " INTEGER, " +
+            		COLUMN_SIGNED_DATA + " TEXT, " +
+            		COLUMN_SIGNATURE + " TEXT)");
         }
 
 		@Override

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/model/Transaction.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/model/Transaction.java
@@ -44,7 +44,7 @@ public class Transaction {
 
 	static final String PURCHASE_TIME = "purchaseTime";
 	
-    public static Transaction parse(JSONObject json) throws JSONException {
+    public static Transaction parse(JSONObject json, String signedData, String signature) throws JSONException {
     	final Transaction transaction = new Transaction();
         final int response = json.getInt(PURCHASE_STATE);
         transaction.purchaseState = PurchaseState.valueOf(response);
@@ -54,6 +54,10 @@ public class Transaction {
         transaction.orderId = json.optString(ORDER_ID, null);
         transaction.notificationId = json.optString(NOTIFICATION_ID, null);
         transaction.developerPayload = json.optString(DEVELOPER_PAYLOAD, null);
+
+        transaction.signedData = signedData;
+        transaction.signature = signature;
+
         return transaction;
     }
 
@@ -64,11 +68,13 @@ public class Transaction {
     public String productId;
     public PurchaseState purchaseState;
     public long purchaseTime;
+    public String signedData;
+    public String signature;
     
     public Transaction() {}
     
     public Transaction(String orderId, String productId, String packageName, PurchaseState purchaseState,
-			String notificationId, long purchaseTime, String developerPayload) {
+			String notificationId, long purchaseTime, String developerPayload, String signedData, String signature) {
 		this.orderId = orderId;
 		this.productId = productId;
 		this.packageName = packageName;
@@ -76,10 +82,12 @@ public class Transaction {
 		this.notificationId = notificationId;
 		this.purchaseTime = purchaseTime;
 		this.developerPayload = developerPayload;
+		this.signedData = signedData;
+		this.signature = signature;
 	}
     
 	public Transaction clone() {
-		return new Transaction(orderId, productId, packageName, purchaseState, notificationId, purchaseTime, developerPayload);
+		return new Transaction(orderId, productId, packageName, purchaseState, notificationId, purchaseTime, developerPayload, signedData, signature);
 	}
 
 	@Override


### PR DESCRIPTION
Hi!  Thanks a lot for this handy library.

I modified the source so that the raw `signedData` and `signature` strings are stored in the BillingDB.  This way I can recover the transactions in my `onPurchaseStateChanged` callback through `BillingController.getTransactions(this)` and send to my server all the information needed to process the transaction **and perform its verification**.

It's a small modification, but I think most user will look after this feature.
