### PR TITLE
Non-backwards compatible changes. Closes #52, closes #90.

### DIFF
--- a/AndroidBillingLibrary/src/net/robotmedia/billing/BillingController.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/BillingController.java
@@ -304,7 +304,7 @@ public class BillingController {
 
 	/**
 	 * Obfuscates the specified purchase. Only the order id, product id and
-	 * developer payload are obfuscated.
+	 * developer payload, signed data and signature are obfuscated.
 	 * 
 	 * @param context
 	 * @param purchase
@@ -319,6 +319,8 @@ public class BillingController {
 		purchase.orderId = Security.obfuscate(context, salt, purchase.orderId);
 		purchase.productId = Security.obfuscate(context, salt, purchase.productId);
 		purchase.developerPayload = Security.obfuscate(context, salt, purchase.developerPayload);
+		purchase.signedData = Security.obfuscate(context, salt, purchase.signedData);
+		purchase.signature = Security.obfuscate(context, salt, purchase.signature);
 	}
 
 	/**
@@ -426,6 +428,11 @@ public class BillingController {
 				// refunds.
 				addManualConfirmation(p.productId, p.notificationId);
 			}
+			
+			// Add signedData and signature as receipt to transaction
+			p.signedData = signedData;
+			p.signature = signature;
+			
 			storeTransaction(context, p);
 			notifyPurchaseStateChange(p.productId, p.purchaseState);
 		}
@@ -713,6 +720,8 @@ public class BillingController {
 		purchase.orderId = Security.unobfuscate(context, salt, purchase.orderId);
 		purchase.productId = Security.unobfuscate(context, salt, purchase.productId);
 		purchase.developerPayload = Security.unobfuscate(context, salt, purchase.developerPayload);
+		purchase.signedData = Security.unobfuscate(context, salt, purchase.signedData);
+		purchase.signature = Security.unobfuscate(context, salt, purchase.signature);
 	}
 
 	/**

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/BillingController.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/BillingController.java
@@ -300,9 +300,9 @@ public class BillingController {
 	 * @param state
 	 *            new purchase state of the item.
 	 */
-	private static void notifyPurchaseStateChange(String itemId, Transaction.PurchaseState state) {
+	private static void notifyPurchaseStateChange(String itemId, Transaction.PurchaseState state, String orderId) {
 		for (IBillingObserver o : observers) {
-			o.onPurchaseStateChanged(itemId, state);
+			o.onPurchaseStateChanged(itemId, state, orderId);
 		}
 	}
 
@@ -470,7 +470,7 @@ public class BillingController {
 			p.signature = signature;
 			
 			storeTransaction(context, p);
-			notifyPurchaseStateChange(p.productId, p.purchaseState);
+			notifyPurchaseStateChange(p.productId, p.purchaseState, p.orderId);
 		}
 		if (!confirmations.isEmpty()) {
 			final String[] notifyIds = confirmations.toArray(new String[confirmations.size()]);

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/BillingController.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/BillingController.java
@@ -398,7 +398,7 @@ public class BillingController {
 		}
 
 		if (debug) {
-			onSignatureValidated(context, signedData);
+			onSignatureValidated(context, signedData, signature);
 			return;
 		}
 		
@@ -420,7 +420,7 @@ public class BillingController {
 			@Override
 			protected void onPostExecute(Boolean result) {
 				if (result) {
-					onSignatureValidated(context, signedData);
+					onSignatureValidated(context, signedData, signature);
 				} else {
 					Log.w(LOG_TAG, "Signature does not match data.");
 				}
@@ -438,8 +438,10 @@ public class BillingController {
 	 * @param context
 	 * @param signedData
 	 *            signed JSON data received from the Market Billing service.
+	 * @param signature
+	 *            data signature.
 	 */
-	private static void onSignatureValidated(Context context, String signedData) {
+	private static void onSignatureValidated(Context context, String signedData, String signature) {
 		List<Transaction> purchases;
 		try {
 			JSONObject jObject = new JSONObject(signedData);

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/BillingController.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/BillingController.java
@@ -580,11 +580,10 @@ public class BillingController {
 	}
 
 	/**
-	 * Requests the purchase of the specified item. The transaction will not be
-	 * confirmed automatically.
+	 * Requests the purchase of the specified item. The transaction will be
+	 * confirmed automatically. If manual confirmation or a developer payload are required use {@link #requestPurchase(Context, String, boolean, String)} instead.
 	 * <p>
-	 * For subscriptions, use {@link #requestSubscription(Context, String)}
-	 * instead.
+	 * For subscriptions, use {@link #requestSubscription(Context, String)}.
 	 * </p>
 	 * 
 	 * @param context
@@ -593,7 +592,7 @@ public class BillingController {
 	 * @see #requestPurchase(Context, String, boolean)
 	 */
 	public static void requestPurchase(Context context, String itemId) {
-		requestPurchase(context, itemId, false, null);
+		requestPurchase(context, itemId, true /* confirm */, null);
 	}
 
 	/**
@@ -626,8 +625,8 @@ public class BillingController {
 	}
 
 	/**
-	 * Requests the purchase of the specified subscription item. The transaction
-	 * will not be confirmed automatically.
+	 * Requests the purchase of the specified subscription item. The transaction will be
+	 * confirmed automatically. If manual confirmation or a developer payload are required use {@link #requestSubscription(Context, String, boolean, String)} instead.
 	 * 
 	 * @param context
 	 * @param itemId
@@ -635,7 +634,7 @@ public class BillingController {
 	 * @see #requestSubscription(Context, String, boolean, String)
 	 */
 	public static void requestSubscription(Context context, String itemId) {
-		requestSubscription(context, itemId, false, null);
+		requestSubscription(context, itemId, true /* confirm */, null);
 	}
 
 	/**

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/BillingController.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/BillingController.java
@@ -37,6 +37,7 @@ import android.app.PendingIntent;
 import android.app.PendingIntent.CanceledException;
 import android.content.Context;
 import android.content.Intent;
+import android.os.AsyncTask;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -60,9 +61,12 @@ public class BillingController {
 
 		/**
 		 * Returns the public key used to verify the signature of responses of
-		 * the Market Billing service.
+		 * the Google Play Billing service. If you are using a custom signature
+		 * validator with server-side validation this method might not be needed
+		 * and can return null.
 		 * 
 		 * @return Base64 encoded public key.
+		 * @see BillingController#setSignatureValidator(ISignatureValidator)
 		 */
 		public String getPublicKey();
 	}
@@ -374,8 +378,8 @@ public class BillingController {
 	/**
 	 * Called after the response to a
 	 * {@link net.robotmedia.billing.request.GetPurchaseInformation} request is
-	 * received. Registers all transactions in local memory and confirms those
-	 * who can be confirmed automatically.
+	 * received. Validates the signature asynchronously and calls
+	 * {@link #onSignatureValidated(Context, String)} if successful.
 	 * 
 	 * @param context
 	 * @param signedData
@@ -383,7 +387,7 @@ public class BillingController {
 	 * @param signature
 	 *            data signature.
 	 */
-	protected static void onPurchaseStateChanged(Context context, String signedData, String signature) {
+	protected static void onPurchaseStateChanged(final Context context, final String signedData, final String signature) {
 		debug("Purchase state changed");
 		
 		if (TextUtils.isEmpty(signedData)) {
@@ -393,19 +397,49 @@ public class BillingController {
 			debug(signedData);
 		}
 
-		if (!debug) {
-			if (TextUtils.isEmpty(signature)) {
-				Log.w(LOG_TAG, "Empty signature requires debug mode");
-				return;
-			}
-			final ISignatureValidator validator = BillingController.validator != null ? BillingController.validator
-					: new DefaultSignatureValidator(BillingController.configuration);
-			if (!validator.validate(signedData, signature)) {
-				Log.w(LOG_TAG, "Signature does not match data.");
-				return;
-			}
+		if (debug) {
+			onSignatureValidated(context, signedData);
+			return;
 		}
+		
+		if (TextUtils.isEmpty(signature)) {
+			Log.w(LOG_TAG, "Empty signature requires debug mode");
+			return;
+		}
+		final ISignatureValidator validator = BillingController.validator != null ? BillingController.validator
+				: new DefaultSignatureValidator(BillingController.configuration);
 
+		// Use AsyncTask mostly in case the signature is validated remotely
+		new AsyncTask<Void, Void, Boolean>() {
+
+			@Override
+			protected Boolean doInBackground(Void... params) {
+				return validator.validate(signedData, signature);
+			}
+
+			@Override
+			protected void onPostExecute(Boolean result) {
+				if (result) {
+					onSignatureValidated(context, signedData);
+				} else {
+					Log.w(LOG_TAG, "Signature does not match data.");
+				}
+			}
+
+		}.execute();
+	}
+	
+	/**
+	 * Called after the signature of a response to a
+	 * {@link net.robotmedia.billing.request.GetPurchaseInformation} request has
+	 * been validated. Registers all transactions in local memory and confirms
+	 * those who can be confirmed automatically.
+	 * 
+	 * @param context
+	 * @param signedData
+	 *            signed JSON data received from the Market Billing service.
+	 */
+	private static void onSignatureValidated(Context context, String signedData) {
 		List<Transaction> purchases;
 		try {
 			JSONObject jObject = new JSONObject(signedData);
@@ -439,7 +473,7 @@ public class BillingController {
 		if (!confirmations.isEmpty()) {
 			final String[] notifyIds = confirmations.toArray(new String[confirmations.size()]);
 			confirmNotifications(context, notifyIds);
-		}
+		}		
 	}
 
 	/**

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/BillingController.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/BillingController.java
@@ -422,7 +422,7 @@ public class BillingController {
 				if (result) {
 					onSignatureValidated(context, signedData, signature);
 				} else {
-					Log.w(LOG_TAG, "Signature does not match data.");
+					Log.w(LOG_TAG, "Validation failed");
 				}
 			}
 

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/IBillingObserver.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/IBillingObserver.java
@@ -61,8 +61,12 @@ public interface IBillingObserver {
 	 *            id of the item whose purchase state has changed.
 	 * @param state
 	 *            purchase state of the specified item.
+	 * @param orderId
+	 *            id of the corresponding order. This is particularly useful to
+	 *            differentiate between different orders of the same unmanaged
+	 *            item.
 	 */
-	public void onPurchaseStateChanged(String itemId, PurchaseState state);
+	public void onPurchaseStateChanged(String itemId, PurchaseState state, String orderId);
 
 	/**
 	 * Called with the response for the purchase request of the specified item.

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/helper/AbstractBillingActivity.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/helper/AbstractBillingActivity.java
@@ -89,8 +89,8 @@ public abstract class AbstractBillingActivity extends Activity implements Billin
 				AbstractBillingActivity.this.onSubscriptionChecked(supported);
 			}
 
-			public void onPurchaseStateChanged(String itemId, PurchaseState state) {
-				AbstractBillingActivity.this.onPurchaseStateChanged(itemId, state);
+			public void onPurchaseStateChanged(String itemId, PurchaseState state, String orderId) {
+				AbstractBillingActivity.this.onPurchaseStateChanged(itemId, state, orderId);
 			}
 
 			public void onRequestPurchaseResponse(String itemId, ResponseCode response) {
@@ -116,7 +116,7 @@ public abstract class AbstractBillingActivity extends Activity implements Billin
 		BillingController.setConfiguration(null);
 	}
 
-	public abstract void onPurchaseStateChanged(String itemId, PurchaseState state);;
+	public abstract void onPurchaseStateChanged(String itemId, PurchaseState state, String orderId);
 
 	public abstract void onRequestPurchaseResponse(String itemId, ResponseCode response);
 

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/helper/AbstractBillingActivity.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/helper/AbstractBillingActivity.java
@@ -121,11 +121,9 @@ public abstract class AbstractBillingActivity extends Activity implements Billin
 	public abstract void onRequestPurchaseResponse(String itemId, ResponseCode response);
 
 	/**
-	 * Requests the purchase of the specified item. The transaction will not be
-	 * confirmed automatically; such confirmation could be handled in
-	 * {@link AbstractBillingActivity#onPurchaseExecuted(String)}. If automatic
-	 * confirmation is preferred use
-	 * {@link BillingController#requestPurchase(android.content.Context, String, boolean)}
+	 * Requests the purchase of the specified item. The transaction will be
+	 * confirmed automatically. If manual confirmation is required use
+	 * {@link BillingController#requestPurchase(android.content.Context, String, boolean, String)}
 	 * instead.
 	 * 
 	 * @param itemId
@@ -137,10 +135,8 @@ public abstract class AbstractBillingActivity extends Activity implements Billin
 
 	/**
 	 * Requests the purchase of the specified subscription item. The transaction
-	 * will not be confirmed automatically; such confirmation could be handled
-	 * in {@link AbstractBillingActivity#onPurchaseExecuted(String)}. If
-	 * automatic confirmation is preferred use
-	 * {@link BillingController#requestPurchase(android.content.Context, String, boolean)}
+	 * will be confirmed automatically. If manual confirmation is required use
+	 * {@link BillingController#requestSubscription(android.content.Context, String, boolean, String)}
 	 * instead.
 	 * 
 	 * @param itemId

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/helper/AbstractBillingFragment.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/helper/AbstractBillingFragment.java
@@ -108,11 +108,9 @@ public abstract class AbstractBillingFragment extends Fragment implements Billin
 	public abstract void onRequestPurchaseResponse(String itemId, ResponseCode response);
 
 	/**
-	 * Requests the purchase of the specified item. The transaction will not be
-	 * confirmed automatically; such confirmation could be handled in
-	 * {@link AbstractBillingActivity#onPurchaseExecuted(String)}. If automatic
-	 * confirmation is preferred use
-	 * {@link BillingController#requestPurchase(android.content.Context, String, boolean)}
+	 * Requests the purchase of the specified item. The transaction will be
+	 * confirmed automatically. If manual confirmation is required use
+	 * {@link BillingController#requestPurchase(android.content.Context, String, boolean, String)}
 	 * instead.
 	 * 
 	 * @param itemId
@@ -124,10 +122,8 @@ public abstract class AbstractBillingFragment extends Fragment implements Billin
 
 	/**
 	 * Requests the purchase of the specified subscription item. The transaction
-	 * will not be confirmed automatically; such confirmation could be handled
-	 * in {@link AbstractBillingActivity#onPurchaseExecuted(String)}. If
-	 * automatic confirmation is preferred use
-	 * {@link BillingController#requestPurchase(android.content.Context, String, boolean)}
+	 * will be confirmed automatically. If manual confirmation is required use
+	 * {@link BillingController#requestSubscription(android.content.Context, String, boolean, String)}
 	 * instead.
 	 * 
 	 * @param itemId

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/helper/AbstractBillingFragment.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/helper/AbstractBillingFragment.java
@@ -76,8 +76,8 @@ public abstract class AbstractBillingFragment extends Fragment implements Billin
 				AbstractBillingFragment.this.onSubscriptionChecked(supported);
 			}
 
-			public void onPurchaseStateChanged(String itemId, PurchaseState state) {
-				AbstractBillingFragment.this.onPurchaseStateChanged(itemId, state);
+			public void onPurchaseStateChanged(String itemId, PurchaseState state, String orderId) {
+				AbstractBillingFragment.this.onPurchaseStateChanged(itemId, state, orderId);
 			}
 
 			public void onRequestPurchaseResponse(String itemId, ResponseCode response) {
@@ -103,7 +103,7 @@ public abstract class AbstractBillingFragment extends Fragment implements Billin
 		BillingController.setConfiguration(null);
 	}
 
-	public abstract void onPurchaseStateChanged(String itemId, PurchaseState state);;
+	public abstract void onPurchaseStateChanged(String itemId, PurchaseState state, String orderId);
 
 	public abstract void onRequestPurchaseResponse(String itemId, ResponseCode response);
 

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/model/BillingDB.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/model/BillingDB.java
@@ -24,7 +24,7 @@ import android.database.sqlite.SQLiteOpenHelper;
 
 public class BillingDB {
     static final String DATABASE_NAME = "billing.db";
-    static final int DATABASE_VERSION = 1;
+    static final int DATABASE_VERSION = 2;
     static final String TABLE_TRANSACTIONS = "purchases";
 
     public static final String COLUMN__ID = "_id";
@@ -32,10 +32,13 @@ public class BillingDB {
     public static final String COLUMN_PRODUCT_ID = "productId";
     public static final String COLUMN_PURCHASE_TIME = "purchaseTime";
     public static final String COLUMN_DEVELOPER_PAYLOAD = "developerPayload";
+    public static final String COLUMN_SIGNED_DATA = "signedData";
+    public static final String COLUMN_SIGNATURE = "signature";
 
     private static final String[] TABLE_TRANSACTIONS_COLUMNS = {
     	COLUMN__ID, COLUMN_PRODUCT_ID, COLUMN_STATE,
-    	COLUMN_PURCHASE_TIME, COLUMN_DEVELOPER_PAYLOAD
+    	COLUMN_PURCHASE_TIME, COLUMN_DEVELOPER_PAYLOAD,
+    	COLUMN_SIGNED_DATA, COLUMN_SIGNATURE
     };
 
     SQLiteDatabase mDb;
@@ -57,6 +60,8 @@ public class BillingDB {
         values.put(COLUMN_STATE, transaction.purchaseState.ordinal());
         values.put(COLUMN_PURCHASE_TIME, transaction.purchaseTime);
         values.put(COLUMN_DEVELOPER_PAYLOAD, transaction.developerPayload);
+        values.put(COLUMN_SIGNED_DATA, transaction.signedData);
+        values.put(COLUMN_SIGNATURE, transaction.signature);
         mDb.replace(TABLE_TRANSACTIONS, null /* nullColumnHack */, values);
     }
     
@@ -82,6 +87,8 @@ public class BillingDB {
     	purchase.purchaseState = PurchaseState.valueOf(cursor.getInt(2));
     	purchase.purchaseTime = cursor.getLong(3);
     	purchase.developerPayload = cursor.getString(4);
+    	purchase.signedData = cursor.getString(5);
+    	purchase.signature = cursor.getString(6);
     	return purchase;
     }
 
@@ -101,10 +108,25 @@ public class BillingDB {
             		COLUMN_PRODUCT_ID + " INTEGER, " +
             		COLUMN_STATE + " TEXT, " +
             		COLUMN_PURCHASE_TIME + " TEXT, " +
-            		COLUMN_DEVELOPER_PAYLOAD + " INTEGER)");
+            		COLUMN_DEVELOPER_PAYLOAD + " INTEGER, " +
+            		COLUMN_SIGNED_DATA + " TEXT," +
+            		COLUMN_SIGNATURE + " TEXT)");
         }
 
 		@Override
-		public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {}
+		public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+			if (oldVersion == 1 && newVersion == 2) {
+				db.beginTransaction();
+				try {
+					db.execSQL("ALTER TABLE " + TABLE_TRANSACTIONS + 
+							" ADD COLUMN " + COLUMN_SIGNED_DATA + " TEXT");
+					db.execSQL("ALTER TABLE " + TABLE_TRANSACTIONS + 
+							" ADD COLUMN " + COLUMN_SIGNATURE + " TEXT");
+					db.setTransactionSuccessful();
+				} finally {
+					db.endTransaction();
+				}
+			}
+		}
     }
 }

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/model/BillingDB.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/model/BillingDB.java
@@ -92,7 +92,7 @@ public class BillingDB {
     	return purchase;
     }
 
-    private class DatabaseHelper extends SQLiteOpenHelper {
+    public static class DatabaseHelper extends SQLiteOpenHelper {
         public DatabaseHelper(Context context) {
             super(context, DATABASE_NAME, null, DATABASE_VERSION);
         }
@@ -105,10 +105,10 @@ public class BillingDB {
         private void createTransactionsTable(SQLiteDatabase db) {
             db.execSQL("CREATE TABLE " + TABLE_TRANSACTIONS + "(" +
             		COLUMN__ID + " TEXT PRIMARY KEY, " +
-            		COLUMN_PRODUCT_ID + " INTEGER, " +
+            		COLUMN_PRODUCT_ID + " TEXT, " +
             		COLUMN_STATE + " TEXT, " +
             		COLUMN_PURCHASE_TIME + " TEXT, " +
-            		COLUMN_DEVELOPER_PAYLOAD + " INTEGER, " +
+            		COLUMN_DEVELOPER_PAYLOAD + " TEXT, " +
             		COLUMN_SIGNED_DATA + " TEXT," +
             		COLUMN_SIGNATURE + " TEXT)");
         }

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/model/Transaction.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/model/Transaction.java
@@ -39,6 +39,7 @@ public class Transaction {
             return values[index];
         }
     }
+    
 	static final String DEVELOPER_PAYLOAD = "developerPayload";
 	static final String NOTIFICATION_ID = "notificationId";
 	static final String ORDER_ID = "orderId";
@@ -61,6 +62,8 @@ public class Transaction {
         return transaction;
     }
 
+    public String signedData;
+    public String signature;
 	public String developerPayload;
     public String notificationId;
     public String orderId;
@@ -82,8 +85,21 @@ public class Transaction {
 		this.developerPayload = developerPayload;
 	}
     
+    public Transaction(String orderId, String productId, String packageName, PurchaseState purchaseState,
+			String notificationId, long purchaseTime, String developerPayload, String signature, String signedData) {
+		this.orderId = orderId;
+		this.productId = productId;
+		this.packageName = packageName;
+		this.purchaseState = purchaseState;
+		this.notificationId = notificationId;
+		this.purchaseTime = purchaseTime;
+		this.developerPayload = developerPayload;
+		this.signature = signature;
+		this.signedData = signedData;
+	}
+    
 	public Transaction clone() {
-		return new Transaction(orderId, productId, packageName, purchaseState, notificationId, purchaseTime, developerPayload);
+		return new Transaction(orderId, productId, packageName, purchaseState, notificationId, purchaseTime, developerPayload, signature, signedData);
 	}
 
 	@Override
@@ -124,6 +140,19 @@ public class Transaction {
 			return false;
 		if (purchaseTime != other.purchaseTime)
 			return false;
+		
+		if (signature == null) {
+			if (other.signature != null)
+				return false;
+		} else if (!signature.equals(other.signature))
+			return false;
+		
+		if (signedData == null) {
+			if (other.signedData != null)
+				return false;
+		} else if (!signedData.equals(other.signedData))
+			return false;
+		
 		return true;
 	}
 	
@@ -131,5 +160,4 @@ public class Transaction {
 	public String toString() {
 		return String.valueOf(orderId);
 	}
-    
 }

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/model/Transaction.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/model/Transaction.java
@@ -75,17 +75,6 @@ public class Transaction {
     public Transaction() {}
     
     public Transaction(String orderId, String productId, String packageName, PurchaseState purchaseState,
-			String notificationId, long purchaseTime, String developerPayload) {
-		this.orderId = orderId;
-		this.productId = productId;
-		this.packageName = packageName;
-		this.purchaseState = purchaseState;
-		this.notificationId = notificationId;
-		this.purchaseTime = purchaseTime;
-		this.developerPayload = developerPayload;
-	}
-    
-    public Transaction(String orderId, String productId, String packageName, PurchaseState purchaseState,
 			String notificationId, long purchaseTime, String developerPayload, String signature, String signedData) {
 		this.orderId = orderId;
 		this.productId = productId;
@@ -140,19 +129,16 @@ public class Transaction {
 			return false;
 		if (purchaseTime != other.purchaseTime)
 			return false;
-		
 		if (signature == null) {
 			if (other.signature != null)
 				return false;
 		} else if (!signature.equals(other.signature))
 			return false;
-		
 		if (signedData == null) {
 			if (other.signedData != null)
 				return false;
 		} else if (!signedData.equals(other.signedData))
 			return false;
-		
 		return true;
 	}
 	

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/security/ISignatureValidator.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/security/ISignatureValidator.java
@@ -25,7 +25,8 @@ public interface ISignatureValidator {
 	 *            signed data
 	 * @param signature
 	 *            signature
-	 * @return true if the data and signature match, false otherwise.
+	 * @return true if the data and signature match, false otherwise or if there
+	 *         was an error during validation.
 	 */
 	public boolean validate(String signedData, String signature);
 

--- a/AndroidBillingLibraryTest/src/net/robotmedia/billing/helper/MockBillingActivity.java
+++ b/AndroidBillingLibraryTest/src/net/robotmedia/billing/helper/MockBillingActivity.java
@@ -46,7 +46,7 @@ public class MockBillingActivity extends AbstractBillingActivity {
 	}
 
 	@Override
-	public void onPurchaseStateChanged(String itemId, PurchaseState state) {
+	public void onPurchaseStateChanged(String itemId, PurchaseState state, String orderId) {
 		// TODO Auto-generated method stub
 	}
 

--- a/AndroidBillingLibraryTest/src/net/robotmedia/billing/helper/MockBillingObserver.java
+++ b/AndroidBillingLibraryTest/src/net/robotmedia/billing/helper/MockBillingObserver.java
@@ -16,7 +16,7 @@ public class MockBillingObserver implements IBillingObserver {
 	public void onPurchaseIntent(String itemId, PendingIntent purchaseIntent) {
 	}
 
-	public void onPurchaseStateChanged(String itemId, PurchaseState state) {
+	public void onPurchaseStateChanged(String itemId, PurchaseState state, String orderId) {
 	}
 
 	public void onRequestPurchaseResponse(String itemId, ResponseCode response) {

--- a/AndroidBillingLibraryTest/src/net/robotmedia/billing/model/BillingDBTest.java
+++ b/AndroidBillingLibraryTest/src/net/robotmedia/billing/model/BillingDBTest.java
@@ -152,14 +152,18 @@ public class BillingDBTest extends AndroidTestCase {
 		assertEquals(found, result);
 	}
 	
+	private void testTable(SQLiteDatabase db, String table) {
+		Cursor cursor = db.query("sqlite_master", new String[] {"name"}, "type='table' AND name='" + table + "'", null, null, null, null);
+		assertTrue(cursor.getCount() > 0);
+		cursor.close();
+	}
+	
 	@SmallTest
 	public void testDatabaseHelperOnCreate() throws Exception {
 		BillingDB.DatabaseHelper helper = new BillingDB.DatabaseHelper(this.getContext());
 		SQLiteDatabase db = SQLiteDatabase.create(null);
 		helper.onCreate(db);
-		Cursor cursor = db.query("sqlite_master", new String[] {"name"}, "type='table' AND name='" + BillingDB.TABLE_TRANSACTIONS + "'", null, null, null, null);
-		assertTrue(cursor.getCount() > 0);
-		cursor.close();
+		testTable(db, BillingDB.TABLE_TRANSACTIONS);
 		testColumn(db, BillingDB.COLUMN__ID, "TEXT", true);
 		testColumn(db, BillingDB.COLUMN_PRODUCT_ID, "TEXT", true);
 		testColumn(db, BillingDB.COLUMN_STATE, "TEXT", true);
@@ -174,7 +178,6 @@ public class BillingDBTest extends AndroidTestCase {
 		BillingDB.DatabaseHelper helper = new BillingDB.DatabaseHelper(this.getContext());
 		SQLiteDatabase db = helper.getWritableDatabase();
 		helper.onUpgrade(db, BillingDB.DATABASE_VERSION, BillingDB.DATABASE_VERSION);
-
 	}
 	
 	private SQLiteDatabase createVersion1Database() {

--- a/AndroidBillingLibraryTest/src/net/robotmedia/billing/model/BillingDBTest.java
+++ b/AndroidBillingLibraryTest/src/net/robotmedia/billing/model/BillingDBTest.java
@@ -16,6 +16,7 @@
 package net.robotmedia.billing.model;
 
 import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
 import android.test.AndroidTestCase;
 import android.test.suitebuilder.annotation.SmallTest;
 
@@ -130,4 +131,71 @@ public class BillingDBTest extends AndroidTestCase {
 		cursor2.close();
 	}
 	
+	@SmallTest
+	public void testDatabaseHelperConstructor() throws Exception {
+		BillingDB.DatabaseHelper helper = new BillingDB.DatabaseHelper(this.getContext());
+		assertEquals(helper.getReadableDatabase().getVersion(), BillingDB.DATABASE_VERSION);
+	}
+	
+	private void testColumn(SQLiteDatabase db, String column, String expectedType, boolean result) {
+		Cursor cursor = db.rawQuery("PRAGMA table_info(" +  BillingDB.TABLE_TRANSACTIONS + ")", null);
+		boolean found = false;
+		while (cursor.moveToNext()) {
+			final String name = cursor.getString(1);
+			if (name.equals(column)) {
+				final String type = cursor.getString(2);
+				assertEquals(type, expectedType);
+				found = true;
+			}
+		}
+		cursor.close();
+		assertEquals(found, result);
+	}
+	
+	@SmallTest
+	public void testDatabaseHelperOnCreate() throws Exception {
+		BillingDB.DatabaseHelper helper = new BillingDB.DatabaseHelper(this.getContext());
+		SQLiteDatabase db = SQLiteDatabase.create(null);
+		helper.onCreate(db);
+		Cursor cursor = db.query("sqlite_master", new String[] {"name"}, "type='table' AND name='" + BillingDB.TABLE_TRANSACTIONS + "'", null, null, null, null);
+		assertTrue(cursor.getCount() > 0);
+		cursor.close();
+		testColumn(db, BillingDB.COLUMN__ID, "TEXT", true);
+		testColumn(db, BillingDB.COLUMN_PRODUCT_ID, "TEXT", true);
+		testColumn(db, BillingDB.COLUMN_STATE, "TEXT", true);
+		testColumn(db, BillingDB.COLUMN_PURCHASE_TIME, "TEXT", true);
+		testColumn(db, BillingDB.COLUMN_DEVELOPER_PAYLOAD, "TEXT", true);
+		testColumn(db, BillingDB.COLUMN_SIGNED_DATA, "TEXT", true);
+		testColumn(db, BillingDB.COLUMN_SIGNATURE, "TEXT", true);
+	}
+	
+	@SmallTest
+	public void testDatabaseHelperOnUpgradeCurrentVersion() throws Exception {
+		BillingDB.DatabaseHelper helper = new BillingDB.DatabaseHelper(this.getContext());
+		SQLiteDatabase db = helper.getWritableDatabase();
+		helper.onUpgrade(db, BillingDB.DATABASE_VERSION, BillingDB.DATABASE_VERSION);
+
+	}
+	
+	private SQLiteDatabase createVersion1Database() {
+		final SQLiteDatabase db = SQLiteDatabase.create(null);
+		db.execSQL("CREATE TABLE " + BillingDB.TABLE_TRANSACTIONS + "(" +
+				BillingDB.COLUMN__ID + " TEXT PRIMARY KEY, " +
+				BillingDB.COLUMN_PRODUCT_ID + " INTEGER, " +
+				BillingDB.COLUMN_STATE + " TEXT, " +
+				BillingDB.COLUMN_PURCHASE_TIME + " TEXT, " +
+				BillingDB.COLUMN_DEVELOPER_PAYLOAD + " INTEGER)");
+		return db;
+	}
+	
+	@SmallTest
+	public void testDatabaseHelperOnUpgradeVersion1To2() throws Exception {
+		BillingDB.DatabaseHelper helper = new BillingDB.DatabaseHelper(this.getContext());
+		SQLiteDatabase db = createVersion1Database();
+		testColumn(db, BillingDB.COLUMN_SIGNED_DATA, "TEXT", false);
+		testColumn(db, BillingDB.COLUMN_SIGNATURE, "TEXT", false);
+		helper.onUpgrade(db, 1, 2);
+		testColumn(db, BillingDB.COLUMN_SIGNED_DATA, "TEXT", true);
+		testColumn(db, BillingDB.COLUMN_SIGNATURE, "TEXT", true);
+	}
 }

--- a/AndroidBillingLibraryTest/src/net/robotmedia/billing/model/BillingDBTest.java
+++ b/AndroidBillingLibraryTest/src/net/robotmedia/billing/model/BillingDBTest.java
@@ -22,8 +22,6 @@ import android.test.suitebuilder.annotation.SmallTest;
 
 public class BillingDBTest extends AndroidTestCase {
 
-	private BillingDB mData;
-	
 	public static void assertEqualsFromDb(Transaction a, Transaction b) {
 		assertEquals(a.orderId, b.orderId);
 		assertEquals(a.productId, b.productId);
@@ -32,23 +30,90 @@ public class BillingDBTest extends AndroidTestCase {
 		assertEquals(a.developerPayload, b.developerPayload);
 	}
 	
-	@Override
-	protected void setUp() throws Exception {
-		super.setUp();
-		mData = new BillingDB(getContext());
-	}
-	
 	public static final void deleteDB(BillingDB data) {
 		data.mDb.delete(BillingDB.TABLE_TRANSACTIONS, null, null);
 		data.close();
 	}
 	
+	private BillingDB mData;
+	
+	private SQLiteDatabase createVersion1Database() {
+		final SQLiteDatabase db = SQLiteDatabase.create(null);
+		db.execSQL("CREATE TABLE " + BillingDB.TABLE_TRANSACTIONS + "(" +
+				BillingDB.COLUMN__ID + " TEXT PRIMARY KEY, " +
+				BillingDB.COLUMN_PRODUCT_ID + " INTEGER, " +
+				BillingDB.COLUMN_STATE + " TEXT, " +
+				BillingDB.COLUMN_PURCHASE_TIME + " TEXT, " +
+				BillingDB.COLUMN_DEVELOPER_PAYLOAD + " INTEGER)");
+		return db;
+	}
+	
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		mData = new BillingDB(getContext());
+	}
+		
 	@Override
 	protected void tearDown() throws Exception {
 		super.tearDown();
 		deleteDB(mData);
 	}
-		
+
+	private void testColumn(SQLiteDatabase db, String column, String expectedType, boolean result) {
+		Cursor cursor = db.rawQuery("PRAGMA table_info(" +  BillingDB.TABLE_TRANSACTIONS + ")", null);
+		boolean found = false;
+		while (cursor.moveToNext()) {
+			final String name = cursor.getString(1);
+			if (name.equals(column)) {
+				final String type = cursor.getString(2);
+				assertEquals(type, expectedType);
+				found = true;
+			}
+		}
+		cursor.close();
+		assertEquals(found, result);
+	}
+	
+	@SmallTest
+	public void testDatabaseHelperConstructor() throws Exception {
+		BillingDB.DatabaseHelper helper = new BillingDB.DatabaseHelper(this.getContext());
+		assertEquals(helper.getReadableDatabase().getVersion(), BillingDB.DATABASE_VERSION);
+	}
+	
+	@SmallTest
+	public void testDatabaseHelperOnCreate() throws Exception {
+		BillingDB.DatabaseHelper helper = new BillingDB.DatabaseHelper(this.getContext());
+		SQLiteDatabase db = SQLiteDatabase.create(null);
+		helper.onCreate(db);
+		testTable(db, BillingDB.TABLE_TRANSACTIONS);
+		testColumn(db, BillingDB.COLUMN__ID, "TEXT", true);
+		testColumn(db, BillingDB.COLUMN_PRODUCT_ID, "TEXT", true);
+		testColumn(db, BillingDB.COLUMN_STATE, "TEXT", true);
+		testColumn(db, BillingDB.COLUMN_PURCHASE_TIME, "TEXT", true);
+		testColumn(db, BillingDB.COLUMN_DEVELOPER_PAYLOAD, "TEXT", true);
+		testColumn(db, BillingDB.COLUMN_SIGNED_DATA, "TEXT", true);
+		testColumn(db, BillingDB.COLUMN_SIGNATURE, "TEXT", true);
+	}
+	
+	@SmallTest
+	public void testDatabaseHelperOnUpgradeCurrentVersion() throws Exception {
+		BillingDB.DatabaseHelper helper = new BillingDB.DatabaseHelper(this.getContext());
+		SQLiteDatabase db = helper.getWritableDatabase();
+		helper.onUpgrade(db, BillingDB.DATABASE_VERSION, BillingDB.DATABASE_VERSION);
+	}
+	
+	@SmallTest
+	public void testDatabaseHelperOnUpgradeVersion1To2() throws Exception {
+		BillingDB.DatabaseHelper helper = new BillingDB.DatabaseHelper(this.getContext());
+		SQLiteDatabase db = createVersion1Database();
+		testColumn(db, BillingDB.COLUMN_SIGNED_DATA, "TEXT", false);
+		testColumn(db, BillingDB.COLUMN_SIGNATURE, "TEXT", false);
+		helper.onUpgrade(db, 1, 2);
+		testColumn(db, BillingDB.COLUMN_SIGNED_DATA, "TEXT", true);
+		testColumn(db, BillingDB.COLUMN_SIGNATURE, "TEXT", true);
+	}
+	
 	@SmallTest
 	public void testInsert() throws Exception {
 		mData.insert(TransactionTest.TRANSACTION_1);
@@ -59,14 +124,6 @@ public class BillingDBTest extends AndroidTestCase {
 		stored.packageName = TransactionTest.TRANSACTION_1.packageName; // Not stored in DB
 		stored.notificationId = TransactionTest.TRANSACTION_1.notificationId; // Not stored in DB
 		assertEqualsFromDb(TransactionTest.TRANSACTION_1, stored);
-	}
-
-	@SmallTest
-	public void testUnique() throws Exception {
-		mData.insert(TransactionTest.TRANSACTION_1);
-		mData.insert(TransactionTest.TRANSACTION_1);
-		final Cursor cursor = mData.queryTransactions();
-		assertEquals(cursor.getCount(), 1);
 	}
 	
 	@SmallTest
@@ -131,27 +188,6 @@ public class BillingDBTest extends AndroidTestCase {
 		cursor2.close();
 	}
 	
-	@SmallTest
-	public void testDatabaseHelperConstructor() throws Exception {
-		BillingDB.DatabaseHelper helper = new BillingDB.DatabaseHelper(this.getContext());
-		assertEquals(helper.getReadableDatabase().getVersion(), BillingDB.DATABASE_VERSION);
-	}
-	
-	private void testColumn(SQLiteDatabase db, String column, String expectedType, boolean result) {
-		Cursor cursor = db.rawQuery("PRAGMA table_info(" +  BillingDB.TABLE_TRANSACTIONS + ")", null);
-		boolean found = false;
-		while (cursor.moveToNext()) {
-			final String name = cursor.getString(1);
-			if (name.equals(column)) {
-				final String type = cursor.getString(2);
-				assertEquals(type, expectedType);
-				found = true;
-			}
-		}
-		cursor.close();
-		assertEquals(found, result);
-	}
-	
 	private void testTable(SQLiteDatabase db, String table) {
 		Cursor cursor = db.query("sqlite_master", new String[] {"name"}, "type='table' AND name='" + table + "'", null, null, null, null);
 		assertTrue(cursor.getCount() > 0);
@@ -159,46 +195,10 @@ public class BillingDBTest extends AndroidTestCase {
 	}
 	
 	@SmallTest
-	public void testDatabaseHelperOnCreate() throws Exception {
-		BillingDB.DatabaseHelper helper = new BillingDB.DatabaseHelper(this.getContext());
-		SQLiteDatabase db = SQLiteDatabase.create(null);
-		helper.onCreate(db);
-		testTable(db, BillingDB.TABLE_TRANSACTIONS);
-		testColumn(db, BillingDB.COLUMN__ID, "TEXT", true);
-		testColumn(db, BillingDB.COLUMN_PRODUCT_ID, "TEXT", true);
-		testColumn(db, BillingDB.COLUMN_STATE, "TEXT", true);
-		testColumn(db, BillingDB.COLUMN_PURCHASE_TIME, "TEXT", true);
-		testColumn(db, BillingDB.COLUMN_DEVELOPER_PAYLOAD, "TEXT", true);
-		testColumn(db, BillingDB.COLUMN_SIGNED_DATA, "TEXT", true);
-		testColumn(db, BillingDB.COLUMN_SIGNATURE, "TEXT", true);
-	}
-	
-	@SmallTest
-	public void testDatabaseHelperOnUpgradeCurrentVersion() throws Exception {
-		BillingDB.DatabaseHelper helper = new BillingDB.DatabaseHelper(this.getContext());
-		SQLiteDatabase db = helper.getWritableDatabase();
-		helper.onUpgrade(db, BillingDB.DATABASE_VERSION, BillingDB.DATABASE_VERSION);
-	}
-	
-	private SQLiteDatabase createVersion1Database() {
-		final SQLiteDatabase db = SQLiteDatabase.create(null);
-		db.execSQL("CREATE TABLE " + BillingDB.TABLE_TRANSACTIONS + "(" +
-				BillingDB.COLUMN__ID + " TEXT PRIMARY KEY, " +
-				BillingDB.COLUMN_PRODUCT_ID + " INTEGER, " +
-				BillingDB.COLUMN_STATE + " TEXT, " +
-				BillingDB.COLUMN_PURCHASE_TIME + " TEXT, " +
-				BillingDB.COLUMN_DEVELOPER_PAYLOAD + " INTEGER)");
-		return db;
-	}
-	
-	@SmallTest
-	public void testDatabaseHelperOnUpgradeVersion1To2() throws Exception {
-		BillingDB.DatabaseHelper helper = new BillingDB.DatabaseHelper(this.getContext());
-		SQLiteDatabase db = createVersion1Database();
-		testColumn(db, BillingDB.COLUMN_SIGNED_DATA, "TEXT", false);
-		testColumn(db, BillingDB.COLUMN_SIGNATURE, "TEXT", false);
-		helper.onUpgrade(db, 1, 2);
-		testColumn(db, BillingDB.COLUMN_SIGNED_DATA, "TEXT", true);
-		testColumn(db, BillingDB.COLUMN_SIGNATURE, "TEXT", true);
+	public void testUnique() throws Exception {
+		mData.insert(TransactionTest.TRANSACTION_1);
+		mData.insert(TransactionTest.TRANSACTION_1);
+		final Cursor cursor = mData.queryTransactions();
+		assertEquals(cursor.getCount(), 1);
 	}
 }

--- a/AndroidBillingLibraryTest/src/net/robotmedia/billing/model/TransactionTest.java
+++ b/AndroidBillingLibraryTest/src/net/robotmedia/billing/model/TransactionTest.java
@@ -25,26 +25,39 @@ import junit.framework.TestCase;
 
 public class TransactionTest extends TestCase {
 	
-	public static final Transaction TRANSACTION_1 = new Transaction("order1", "android.test.purchased", "com.example", Transaction.PurchaseState.PURCHASED, "notificationId", new Date().getTime(), "developerPayload");
-	public static final Transaction TRANSACTION_2 = new Transaction("order2", "product_2", "com.example", Transaction.PurchaseState.PURCHASED, "notificationId", new Date().getTime(), "developerPayload");
-	public static final Transaction TRANSACTION_2_REFUNDED = new Transaction("order4", "product_2", "com.example", Transaction.PurchaseState.REFUNDED, "notificationId", new Date().getTime(), "developerPayload");
-	public static final Transaction TRANSACTION_1_REFUNDED = new Transaction("order3", "android.test.purchased", "com.example", Transaction.PurchaseState.REFUNDED, "notificationId", new Date().getTime(), "developerPayload");
+	public static final Transaction TRANSACTION_1 = new Transaction("order1", "android.test.purchased", "com.example", Transaction.PurchaseState.PURCHASED, "notificationId", new Date().getTime(), "developerPayload", "signature", "signedData");
+	public static final Transaction TRANSACTION_2 = new Transaction("order2", "product_2", "com.example", Transaction.PurchaseState.PURCHASED, "notificationId", new Date().getTime(), "developerPayload", "signature", "signedData");
+	public static final Transaction TRANSACTION_2_REFUNDED = new Transaction("order4", "product_2", "com.example", Transaction.PurchaseState.REFUNDED, "notificationId", new Date().getTime(), "developerPayload", "signature", "signedData");
+	public static final Transaction TRANSACTION_1_REFUNDED = new Transaction("order3", "android.test.purchased", "com.example", Transaction.PurchaseState.REFUNDED, "notificationId", new Date().getTime(), "developerPayload", "signature", "signedData");
 	public static void assertEquals(Transaction a, Transaction b) {
 		assertTrue(a.equals(b));
 	}
 	
+	private void testParseAllFields(Transaction transaction) throws Exception {
+		JSONObject json = new JSONObject();
+		json.put(Transaction.ORDER_ID, transaction.orderId);
+		json.put(Transaction.PRODUCT_ID, transaction.productId);
+		json.put(Transaction.PACKAGE_NAME, transaction.packageName);
+		json.put(Transaction.PURCHASE_STATE, transaction.purchaseState.ordinal());
+		json.put(Transaction.NOTIFICATION_ID, transaction.notificationId);
+		json.put(Transaction.PURCHASE_TIME, transaction.purchaseTime);
+		json.put(Transaction.DEVELOPER_PAYLOAD, transaction.developerPayload);
+		final Transaction parsed = Transaction.parse(json);
+		assertEquals(transaction.orderId, parsed.orderId);
+		assertEquals(transaction.productId, parsed.productId);
+		assertEquals(transaction.packageName, parsed.packageName);
+		assertEquals(transaction.purchaseState, parsed.purchaseState);
+		assertEquals(transaction.notificationId, parsed.notificationId);
+		assertEquals(transaction.purchaseTime, parsed.purchaseTime);
+		assertEquals(transaction.developerPayload, parsed.developerPayload);
+		assertNull(parsed.signature);
+		assertNull(parsed.signedData);
+	}
+	
 	@SmallTest
 	public void testParseAllFields() throws Exception {
-		JSONObject json = new JSONObject();
-		json.put(Transaction.ORDER_ID, TRANSACTION_1.orderId);
-		json.put(Transaction.PRODUCT_ID, TRANSACTION_1.productId);
-		json.put(Transaction.PACKAGE_NAME, TRANSACTION_1.packageName);
-		json.put(Transaction.PURCHASE_STATE, TRANSACTION_1.purchaseState.ordinal());
-		json.put(Transaction.NOTIFICATION_ID, TRANSACTION_1.notificationId);
-		json.put(Transaction.PURCHASE_TIME, TRANSACTION_1.purchaseTime);
-		json.put(Transaction.DEVELOPER_PAYLOAD, TRANSACTION_1.developerPayload);
-		final Transaction parsed = Transaction.parse(json);
-		assertEquals(TRANSACTION_1, parsed);
+		testParseAllFields(TRANSACTION_1);
+		testParseAllFields(TRANSACTION_2);
 	}
 	
 	@SmallTest
@@ -62,6 +75,8 @@ public class TransactionTest extends TestCase {
 		assertNull(parsed.notificationId);
 		assertEquals(TRANSACTION_1.purchaseTime, parsed.purchaseTime);
 		assertNull(parsed.developerPayload);
+		assertNull(parsed.signature);
+		assertNull(parsed.signedData);
 	}
 	
 	@SmallTest
@@ -76,11 +91,14 @@ public class TransactionTest extends TestCase {
 	public void testEquals() throws Exception {
 		assertTrue(TRANSACTION_1.equals(TRANSACTION_1));
 		assertTrue(TRANSACTION_1.equals(TRANSACTION_1.clone()));
-		assertFalse(TRANSACTION_1.equals(TRANSACTION_2_REFUNDED));
+		assertTrue(TRANSACTION_1.clone().equals(TRANSACTION_1));
+		assertFalse(TRANSACTION_1.equals(TRANSACTION_2));
+		assertFalse(TRANSACTION_2.equals(TRANSACTION_1));
 	}
 	
 	@SmallTest
 	public void testClone() throws Exception {
 		assertEquals(TRANSACTION_1, TRANSACTION_1.clone());
+		assertEquals(TRANSACTION_2, TRANSACTION_2.clone());
 	}
 }

--- a/DungeonsRedux/src/net/robotmedia/billing/example/Dungeons.java
+++ b/DungeonsRedux/src/net/robotmedia/billing/example/Dungeons.java
@@ -144,9 +144,9 @@ public class Dungeons extends Activity {
 
 			public void onClick(View v) {
 				if (mSelectedItem.managed != Managed.SUBSCRIPTION) {
-					BillingController.requestPurchase(Dungeons.this, mSelectedItem.sku, true /* confirm */, null);
+					BillingController.requestPurchase(Dungeons.this, mSelectedItem.sku);
 				} else {
-					BillingController.requestSubscription(Dungeons.this, mSelectedItem.sku, true /* confirm */, null);
+					BillingController.requestSubscription(Dungeons.this, mSelectedItem.sku);
 				}
 			}
 		});

--- a/DungeonsRedux/src/net/robotmedia/billing/example/Dungeons.java
+++ b/DungeonsRedux/src/net/robotmedia/billing/example/Dungeons.java
@@ -73,8 +73,8 @@ public class Dungeons extends Activity {
 				Dungeons.this.onBillingChecked(supported);
 			}
 
-			public void onPurchaseStateChanged(String itemId, PurchaseState state) {
-				Dungeons.this.onPurchaseStateChanged(itemId, state);
+			public void onPurchaseStateChanged(String itemId, PurchaseState state, String orderId) {
+				Dungeons.this.onPurchaseStateChanged(itemId, state, orderId);
 			}
 
 			public void onRequestPurchaseResponse(String itemId, ResponseCode response) {
@@ -112,7 +112,7 @@ public class Dungeons extends Activity {
 		super.onDestroy();
 	}
 
-	public void onPurchaseStateChanged(String itemId, PurchaseState state) {
+	public void onPurchaseStateChanged(String itemId, PurchaseState state, String orderId) {
 		Log.i(TAG, "onPurchaseStateChanged() itemId: " + itemId);
 		updateOwnedItems();
 	}

--- a/README.mdown
+++ b/README.mdown
@@ -14,6 +14,8 @@ Getting Started
 
 * Get acquainted with the [Android In-app Billing][1] documentation.
 
+* No, really. Read the [documentation first][1]. This library saves you from writing code, but not from reading the documentation.
+
 * Add *Android Billing Library* to your project.
 
 * Open the *AndroidManifest.xml* of your application and add this permission...


### PR DESCRIPTION
- IMPORTANT: Requests are now confirmed by default if you use the short version of `requestPurchase` or `requestSubscription`. Please make sure this doesn't break your app.
- Better support for server-side signature validation.  Signature validation is now performed asynchronously.
- Store signedData and signature in the transactions database. This requires an update of the database, so please test thoroughly before updating.
- Added `orderId` to `IBillingObserver.onPurchaseStateChanged`. This is particularly useful to differentiate between different orders of the same unmanaged item, and in general makes it simpler to track orders.
- Bug fix: incorrect types for product id and developer payload in database (fortunately, SQLite didn't mind)
- Bug fix: rebind service on remote exception.
- A few more tests and minor refactoring.
