### PR TITLE
Adding support for purchaseToken field

### DIFF
--- a/AndroidBillingLibrary/.settings/org.eclipse.jdt.core.prefs
+++ b/AndroidBillingLibrary/.settings/org.eclipse.jdt.core.prefs
@@ -1,4 +1,11 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
-org.eclipse.jdt.core.compiler.compliance=1.5
-org.eclipse.jdt.core.compiler.source=1.5
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.6

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/model/BillingDB.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/model/BillingDB.java
@@ -24,7 +24,12 @@ import android.database.sqlite.SQLiteOpenHelper;
 
 public class BillingDB {
     static final String DATABASE_NAME = "billing.db";
-    static final int DATABASE_VERSION = 1;
+
+    /**
+     * Version 1 - Initial Creation
+     * Version 2 - Added column purchaseToken
+     */
+    static final int DATABASE_VERSION = 2;
     static final String TABLE_TRANSACTIONS = "purchases";
 
     public static final String COLUMN__ID = "_id";
@@ -32,10 +37,11 @@ public class BillingDB {
     public static final String COLUMN_PRODUCT_ID = "productId";
     public static final String COLUMN_PURCHASE_TIME = "purchaseTime";
     public static final String COLUMN_DEVELOPER_PAYLOAD = "developerPayload";
+    public static final String COLUMN_PURCHASE_TOKEN = "purchaseToken";
 
     private static final String[] TABLE_TRANSACTIONS_COLUMNS = {
-    	COLUMN__ID, COLUMN_PRODUCT_ID, COLUMN_STATE,
-    	COLUMN_PURCHASE_TIME, COLUMN_DEVELOPER_PAYLOAD
+        COLUMN__ID, COLUMN_PRODUCT_ID, COLUMN_STATE,
+        COLUMN_PURCHASE_TIME, COLUMN_DEVELOPER_PAYLOAD, COLUMN_PURCHASE_TOKEN
     };
 
     SQLiteDatabase mDb;
@@ -57,32 +63,34 @@ public class BillingDB {
         values.put(COLUMN_STATE, transaction.purchaseState.ordinal());
         values.put(COLUMN_PURCHASE_TIME, transaction.purchaseTime);
         values.put(COLUMN_DEVELOPER_PAYLOAD, transaction.developerPayload);
+        values.put(COLUMN_PURCHASE_TOKEN, transaction.purchaseToken);
         mDb.replace(TABLE_TRANSACTIONS, null /* nullColumnHack */, values);
     }
-    
+
     public Cursor queryTransactions() {
         return mDb.query(TABLE_TRANSACTIONS, TABLE_TRANSACTIONS_COLUMNS, null,
                 null, null, null, null);
     }
-    
+
     public Cursor queryTransactions(String productId) {
-        return mDb.query(TABLE_TRANSACTIONS, TABLE_TRANSACTIONS_COLUMNS, COLUMN_PRODUCT_ID + " = ?", 
+        return mDb.query(TABLE_TRANSACTIONS, TABLE_TRANSACTIONS_COLUMNS, COLUMN_PRODUCT_ID + " = ?",
                 new String[] {productId}, null, null, null);
     }
-    
+
     public Cursor queryTransactions(String productId, PurchaseState state) {
-        return mDb.query(TABLE_TRANSACTIONS, TABLE_TRANSACTIONS_COLUMNS, COLUMN_PRODUCT_ID + " = ? AND " + COLUMN_STATE + " = ?", 
+        return mDb.query(TABLE_TRANSACTIONS, TABLE_TRANSACTIONS_COLUMNS, COLUMN_PRODUCT_ID + " = ? AND " + COLUMN_STATE + " = ?",
                 new String[] {productId, String.valueOf(state.ordinal())}, null, null, null);
     }
-    
+
     protected static final Transaction createTransaction(Cursor cursor) {
-    	final Transaction purchase = new Transaction();
-    	purchase.orderId = cursor.getString(0);
-    	purchase.productId = cursor.getString(1);
-    	purchase.purchaseState = PurchaseState.valueOf(cursor.getInt(2));
-    	purchase.purchaseTime = cursor.getLong(3);
-    	purchase.developerPayload = cursor.getString(4);
-    	return purchase;
+        final Transaction purchase = new Transaction();
+        purchase.orderId = cursor.getString(0);
+        purchase.productId = cursor.getString(1);
+        purchase.purchaseState = PurchaseState.valueOf(cursor.getInt(2));
+        purchase.purchaseTime = cursor.getLong(3);
+        purchase.developerPayload = cursor.getString(4);
+        purchase.purchaseToken = cursor.getString(5);
+        return purchase;
     }
 
     private class DatabaseHelper extends SQLiteOpenHelper {
@@ -97,14 +105,22 @@ public class BillingDB {
 
         private void createTransactionsTable(SQLiteDatabase db) {
             db.execSQL("CREATE TABLE " + TABLE_TRANSACTIONS + "(" +
-            		COLUMN__ID + " TEXT PRIMARY KEY, " +
-            		COLUMN_PRODUCT_ID + " INTEGER, " +
-            		COLUMN_STATE + " TEXT, " +
-            		COLUMN_PURCHASE_TIME + " TEXT, " +
-            		COLUMN_DEVELOPER_PAYLOAD + " INTEGER)");
+                    COLUMN__ID + " TEXT PRIMARY KEY, " +
+                    COLUMN_PRODUCT_ID + " INTEGER, " +
+                    COLUMN_STATE + " TEXT, " +
+                    COLUMN_PURCHASE_TIME + " TEXT, " +
+                    COLUMN_DEVELOPER_PAYLOAD + " INTEGER, " +
+                    COLUMN_PURCHASE_TOKEN + " TEXT)");
         }
 
-		@Override
-		public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {}
+        @Override
+        public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+            if (oldVersion < 2) {
+                /* Add in version 2 changes */
+
+                /* Added the purchaseToken column to the table */
+                db.execSQL("ALTER TABLE " + TABLE_TRANSACTIONS + " ADD " + COLUMN_PURCHASE_TOKEN + " TEXT");
+            }
+        }
     }
 }

--- a/AndroidBillingLibrary/src/net/robotmedia/billing/model/Transaction.java
+++ b/AndroidBillingLibrary/src/net/robotmedia/billing/model/Transaction.java
@@ -21,14 +21,14 @@ import org.json.JSONObject;
 public class Transaction {
 
     public enum PurchaseState {
-		// Responses to requestPurchase or restoreTransactions.
-		PURCHASED, // 0: User was charged for the order.
-		CANCELLED, // 1: The charge failed on the server.
-		REFUNDED, // 2: User received a refund for the order.
-		EXPIRED; // 3: Sent at the end of a billing cycle to indicate that the
-					// subscription expired without renewal because of
-					// non-payment or user-cancellation. Your app does not need
-					// to grant continued access to the subscription content.
+        // Responses to requestPurchase or restoreTransactions.
+        PURCHASED, // 0: User was charged for the order.
+        CANCELLED, // 1: The charge failed on the server.
+        REFUNDED, // 2: User received a refund for the order.
+        EXPIRED; // 3: Sent at the end of a billing cycle to indicate that the
+                    // subscription expired without renewal because of
+                    // non-payment or user-cancellation. Your app does not need
+                    // to grant continued access to the subscription content.
 
         // Converts from an ordinal value to the PurchaseState
         public static PurchaseState valueOf(int index) {
@@ -39,17 +39,17 @@ public class Transaction {
             return values[index];
         }
     }
-	static final String DEVELOPER_PAYLOAD = "developerPayload";
-	static final String NOTIFICATION_ID = "notificationId";
-	static final String ORDER_ID = "orderId";
-	static final String PACKAGE_NAME = "packageName";
-	static final String PRODUCT_ID = "productId";
-	static final String PURCHASE_STATE = "purchaseState";
+    static final String DEVELOPER_PAYLOAD = "developerPayload";
+    static final String NOTIFICATION_ID = "notificationId";
+    static final String ORDER_ID = "orderId";
+    static final String PACKAGE_NAME = "packageName";
+    static final String PRODUCT_ID = "productId";
+    static final String PURCHASE_STATE = "purchaseState";
+    static final String PURCHASE_TOKEN = "purchaseToken";
+    static final String PURCHASE_TIME = "purchaseTime";
 
-	static final String PURCHASE_TIME = "purchaseTime";
-	
     public static Transaction parse(JSONObject json) throws JSONException {
-    	final Transaction transaction = new Transaction();
+        final Transaction transaction = new Transaction();
         final int response = json.getInt(PURCHASE_STATE);
         transaction.purchaseState = PurchaseState.valueOf(response);
         transaction.productId = json.getString(PRODUCT_ID);
@@ -58,78 +58,86 @@ public class Transaction {
         transaction.orderId = json.optString(ORDER_ID, null);
         transaction.notificationId = json.optString(NOTIFICATION_ID, null);
         transaction.developerPayload = json.optString(DEVELOPER_PAYLOAD, null);
+        transaction.purchaseToken = json.optString(PURCHASE_TOKEN, null);
         return transaction;
     }
 
-	public String developerPayload;
+    public String developerPayload;
     public String notificationId;
     public String orderId;
     public String packageName;
     public String productId;
     public PurchaseState purchaseState;
     public long purchaseTime;
-    
-    public Transaction() {}
-    
-    public Transaction(String orderId, String productId, String packageName, PurchaseState purchaseState,
-			String notificationId, long purchaseTime, String developerPayload) {
-		this.orderId = orderId;
-		this.productId = productId;
-		this.packageName = packageName;
-		this.purchaseState = purchaseState;
-		this.notificationId = notificationId;
-		this.purchaseTime = purchaseTime;
-		this.developerPayload = developerPayload;
-	}
-    
-	public Transaction clone() {
-		return new Transaction(orderId, productId, packageName, purchaseState, notificationId, purchaseTime, developerPayload);
-	}
+    public String purchaseToken;
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		Transaction other = (Transaction) obj;
-		if (developerPayload == null) {
-			if (other.developerPayload != null)
-				return false;
-		} else if (!developerPayload.equals(other.developerPayload))
-			return false;
-		if (notificationId == null) {
-			if (other.notificationId != null)
-				return false;
-		} else if (!notificationId.equals(other.notificationId))
-			return false;
-		if (orderId == null) {
-			if (other.orderId != null)
-				return false;
-		} else if (!orderId.equals(other.orderId))
-			return false;
-		if (packageName == null) {
-			if (other.packageName != null)
-				return false;
-		} else if (!packageName.equals(other.packageName))
-			return false;
-		if (productId == null) {
-			if (other.productId != null)
-				return false;
-		} else if (!productId.equals(other.productId))
-			return false;
-		if (purchaseState != other.purchaseState)
-			return false;
-		if (purchaseTime != other.purchaseTime)
-			return false;
-		return true;
-	}
-	
-	@Override
-	public String toString() {
-		return String.valueOf(orderId);
-	}
-    
+    public Transaction() {}
+
+    public Transaction(String orderId, String productId, String packageName, PurchaseState purchaseState,
+            String notificationId, long purchaseTime, String developerPayload, String purchaseToken) {
+        this.orderId = orderId;
+        this.productId = productId;
+        this.packageName = packageName;
+        this.purchaseState = purchaseState;
+        this.notificationId = notificationId;
+        this.purchaseTime = purchaseTime;
+        this.purchaseToken = purchaseToken;
+        this.developerPayload = developerPayload;
+    }
+
+    public Transaction clone() {
+        return new Transaction(orderId, productId, packageName, purchaseState, notificationId, purchaseTime, developerPayload, purchaseToken);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Transaction other = (Transaction) obj;
+        if (developerPayload == null) {
+            if (other.developerPayload != null)
+                return false;
+        } else if (!developerPayload.equals(other.developerPayload))
+            return false;
+        if (notificationId == null) {
+            if (other.notificationId != null)
+                return false;
+        } else if (!notificationId.equals(other.notificationId))
+            return false;
+        if (orderId == null) {
+            if (other.orderId != null)
+                return false;
+        } else if (!orderId.equals(other.orderId))
+            return false;
+        if (packageName == null) {
+            if (other.packageName != null)
+                return false;
+        } else if (!packageName.equals(other.packageName))
+            return false;
+        if (productId == null) {
+            if (other.productId != null)
+                return false;
+        } else if (!productId.equals(other.productId))
+            return false;
+        if (purchaseState != other.purchaseState)
+            return false;
+        if (purchaseTime != other.purchaseTime)
+            return false;
+        if (purchaseToken == null) {
+            if (other.purchaseToken != null)
+                return false;
+        } else if (!purchaseToken.equals(other.purchaseToken))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(orderId);
+    }
+
 }


### PR DESCRIPTION
This adds support for the purchaseToken field that is returned as part of the billing data.

Note:
This will work fine if you app has never shipped with the library yet.

Issue to resolve, when the database is reved to version 2, it should probably clear out all transactions and force them to be restored, so the missing purchaseToken field can be fetched. I do not know the library well enough to do that. Hopefully someone that knows this lib better can take this over from here.
