### PR TITLE
Android Billing Version 3 library information

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -5,6 +5,10 @@ The In-app Billing API was updated to [version 3](https://developer.android.com/
 
 If you're interested in helping to update it to version 3, please fork and send a pull request.
 
+If you want to move to version 3 but don't want to implement it yourself you can try [Android Checkout Library](https://github.com/serso/android-checkout).
+This library supports only Billing API version 3 but has a fallback functionality - if device doesn't support Billing v3 **Checkout** will try to load purchases information from Robotmedia database (read [this](https://github.com/serso/android-checkout#billing-version-2) for more information).
+Note that **Checkout** library is a 3rd party library and is not maintained by Robotmedia.
+
 Android Billing Library
 =======================
 


### PR DESCRIPTION
Starting from January 2015 Android Billing Version 2 will not be available as Google ends its support.
For AndroidBillingLibrary users it might be helpful to know how to upgrade to the newer API version without loosing information from the older one.
